### PR TITLE
Fix Navbar Overlapping issue

### DIFF
--- a/src/Components/Navbar.js
+++ b/src/Components/Navbar.js
@@ -12,6 +12,7 @@ import DialogActions from "@mui/material/DialogActions";
 import DialogContent from "@mui/material/DialogContent";
 import DialogContentText from "@mui/material/DialogContentText";
 import DialogTitle from "@mui/material/DialogTitle";
+import { useEffect } from "react";
 
 const Navlinks = ({ dir, sp }) => {
   const mobile = useMediaQuery("(max-width:768px)");
@@ -152,6 +153,18 @@ const Navlinks = ({ dir, sp }) => {
 const Navbar = () => {
   const mobile = useMediaQuery("(max-width:768px)");
   const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth > 768) {
+        setOpen(false);
+      }
+    };
+   window.addEventListener("resize", handleResize);
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   return (
     <div className="navbar">


### PR DESCRIPTION
### Issue:

The column navbar on the right side is overlapping with the top navbar when transitioning from a lower width to a larger width of the website.

**Steps to Reproduce:**

1. Visit the website.
2. Observe the column navbar on the right side.
3. Adjust the width of the website from lower to larger.

**Screenshot:**
<img width="825" alt="Screenshot 2024-02-25 at 12 29 11 AM" src="https://github.com/PolyPhyHub/PolyPhy-Website/assets/112820522/119d39c8-1099-4796-997f-67e447b5f109">

### Changes:

Implemented a condition to close the side navbar when the width of the webpage is increased. The fix addresses the overlapping issue and ensures a better user experience.

**Updated Design:**

https://github.com/PolyPhyHub/PolyPhy-Website/assets/112820522/c529b3ae-d0ee-4ee9-90d9-50fbb6d2193a




### Additional Notes:

- Tested the fix across various screen sizes to ensure responsiveness.
- Reviewed the code changes to ensure compatibility with different browsers.

This PR resolves the overlapping issue between the column navbar and the top navbar, improving the layout consistency of the website.

