### PR TITLE
feat: changed dropdown color to give visibility

### DIFF
--- a/src/sass/index.css
+++ b/src/sass/index.css
@@ -857,7 +857,7 @@ a {
   -webkit-box-direction: normal;
       -ms-flex-direction: column;
           flex-direction: column;
-  background-color: #323232af;
+  background-color: #495057;
   position: absolute;
   left: -20%;
   z-index: 999;


### PR DESCRIPTION
![image](https://github.com/PolyPhyHub/PolyPhy-Website/assets/127925465/ac625169-78b7-41e3-90f2-4ff9d227fbeb)


This PR resolves #16

When there is a text below the dropdown nav menu the text don't conflict