### PR TITLE
[SOLVED] conflicting texts leading to poor visibility

### DIFF
--- a/src/sass/index.css
+++ b/src/sass/index.css
@@ -862,6 +862,7 @@ a {
   left: -20%;
   z-index: 999;
   padding: 0.5rem 0.7rem;
+  backdrop-filter: blur(5px);
 }
 
 @media only screen and (max-width: 550px) {


### PR DESCRIPTION
closes #16 
<img width="1124" alt="Screenshot 2024-03-09 at 5 35 01 PM" src="https://github.com/PolyPhyHub/PolyPhy-Website/assets/112820522/634eba6a-9da7-4c41-a4b2-ab09d39b941e">

added background blur in the dropdown. Now the contents of the dropdown are easily readable.